### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -33,9 +33,9 @@ ESCAPE_DCT = {
 }
 for i in range(0x20):
     #ESCAPE_DCT.setdefault(chr(i), '\\u{0:04x}'.format(i))
-    ESCAPE_DCT.setdefault(chr(i), '\\u%04x' % (i,))
+    ESCAPE_DCT.setdefault(chr(i), '\\u{0:04x}'.format(i))
 for i in [0x2028, 0x2029]:
-    ESCAPE_DCT.setdefault(unichr(i), '\\u%04x' % (i,))
+    ESCAPE_DCT.setdefault(unichr(i), '\\u{0:04x}'.format(i))
 
 FLOAT_REPR = repr
 
@@ -72,14 +72,14 @@ def py_encode_basestring_ascii(s, _PY3=PY3):
             n = ord(s)
             if n < 0x10000:
                 #return '\\u{0:04x}'.format(n)
-                return '\\u%04x' % (n,)
+                return '\\u{0:04x}'.format(n)
             else:
                 # surrogate pair
                 n -= 0x10000
                 s1 = 0xd800 | ((n >> 10) & 0x3ff)
                 s2 = 0xdc00 | (n & 0x3ff)
                 #return '\\u{0:04x}\\u{1:04x}'.format(s1, s2)
-                return '\\u%04x\\u%04x' % (s1, s2)
+                return '\\u{0:04x}\\u{1:04x}'.format(s1, s2)
     return '"' + str(ESCAPE_ASCII.sub(replace, s)) + '"'
 
 

--- a/simplejson/ordered_dict.py
+++ b/simplejson/ordered_dict.py
@@ -20,7 +20,7 @@ class OrderedDict(dict, DictMixin):
 
     def __init__(self, *args, **kwds):
         if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+            raise TypeError('expected at most 1 arguments, got {0:d}'.format(len(args)))
         try:
             self.__end
         except AttributeError:
@@ -96,8 +96,8 @@ class OrderedDict(dict, DictMixin):
 
     def __repr__(self):
         if not self:
-            return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, self.items())
+            return '{0!s}()'.format(self.__class__.__name__)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self.items())
 
     def copy(self):
         return self.__class__(self)

--- a/simplejson/tests/test_decode.py
+++ b/simplejson/tests/test_decode.py
@@ -9,7 +9,7 @@ from simplejson import OrderedDict
 class TestDecode(TestCase):
     if not hasattr(TestCase, 'assertIs'):
         def assertIs(self, a, b):
-            self.assertTrue(a is b, '%r is %r' % (a, b))
+            self.assertTrue(a is b, '{0!r} is {1!r}'.format(a, b))
 
     def test_decimal(self):
         rval = json.loads('1.1', parse_float=decimal.Decimal)

--- a/simplejson/tests/test_encode_basestring_ascii.py
+++ b/simplejson/tests/test_encode_basestring_ascii.py
@@ -39,7 +39,7 @@ class TestEncodeBaseStringAscii(TestCase):
             #    '{0!r} != {1!r} for {2}({3!r})'.format(
             #        result, expect, fname, input_string))
             self.assertEqual(result, expect,
-                '%r != %r for %s(%r)' % (result, expect, fname, input_string))
+                '{0!r} != {1!r} for {2!s}({3!r})'.format(result, expect, fname, input_string))
 
     def test_sorted_dict(self):
         items = [('one', 1), ('two', 2), ('three', 3), ('four', 4), ('five', 5)]

--- a/simplejson/tests/test_fail.py
+++ b/simplejson/tests/test_fail.py
@@ -117,7 +117,7 @@ class TestFail(TestCase):
             except json.JSONDecodeError:
                 pass
             else:
-                self.fail("Expected failure for fail%d.json: %r" % (idx, doc))
+                self.fail("Expected failure for fail{0:d}.json: {1!r}".format(idx, doc))
 
     def test_array_decoder_issue46(self):
         # http://code.google.com/p/simplejson/issues/detail?id=46
@@ -131,7 +131,7 @@ class TestFail(TestCase):
                 self.assertEqual(e.colno, 2)
             except Exception:
                 e = sys.exc_info()[1]
-                self.fail("Unexpected exception raised %r %s" % (e, e))
+                self.fail("Unexpected exception raised {0!r} {1!s}".format(e, e))
             else:
                 self.fail("Unexpected success parsing '[,]'")
 
@@ -165,12 +165,12 @@ class TestFail(TestCase):
                 self.assertEqual(
                     e.msg[:len(msg)],
                     msg,
-                    "%r doesn't start with %r for %r" % (e.msg, msg, data))
+                    "{0!r} doesn't start with {1!r} for {2!r}".format(e.msg, msg, data))
                 self.assertEqual(
                     e.pos, idx,
-                    "pos %r != %r for %r" % (e.pos, idx, data))
+                    "pos {0!r} != {1!r} for {2!r}".format(e.pos, idx, data))
             except Exception:
                 e = sys.exc_info()[1]
-                self.fail("Unexpected exception raised %r %s" % (e, e))
+                self.fail("Unexpected exception raised {0!r} {1!s}".format(e, e))
             else:
-                self.fail("Unexpected success parsing '%r'" % (data,))
+                self.fail("Unexpected success parsing '{0!r}'".format(data))

--- a/simplejson/tests/test_unicode.py
+++ b/simplejson/tests/test_unicode.py
@@ -55,7 +55,7 @@ class TestUnicode(TestCase):
         for i in range(0, 0xd7ff):
             u = unichr(i)
             #s = '"\\u{0:04x}"'.format(i)
-            s = '"\\u%04x"' % (i,)
+            s = '"\\u{0:04x}"'.format(i)
             self.assertEqual(json.loads(s), u)
 
     def test_object_pairs_hook_with_unicode(self):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:simplejson?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:simplejson?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
